### PR TITLE
fix-rate-limiting

### DIFF
--- a/tap_youtube_analytics/client.py
+++ b/tap_youtube_analytics/client.py
@@ -2,7 +2,7 @@ import codecs
 import csv
 from datetime import datetime, timedelta, timezone
 import json
-from typing import Any, Dict, Mapping, Optional, Tuple, Iterator
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Iterator
 
 import backoff
 import requests
@@ -139,7 +139,13 @@ class Client:
             max_tries=7,
             factor=3,
         )
-        def _row_iterator() -> Iterator[Dict[str, Any]]:
+        def _fetch_rows() -> List[Dict[str, Any]]:
+            """Make the HTTP request, read all CSV rows into a list, and return them.
+
+            Using a regular (non-generator) function so that the backoff decorator
+            wraps the actual network I/O and row-reading work, not just the creation
+            of a generator object (which would be a no-op with respect to retries).
+            """
             with metrics.http_request_timer(endpoint) as timer:
                 with self._session.request(
                     "GET",
@@ -163,11 +169,9 @@ class Client:
                         delimiter=",",
                     )
 
-                    for row in reader:
-                        if row:
-                            yield row
+                    return [row for row in reader if row]
 
-        return _row_iterator()
+        yield from _fetch_rows()
 
     @backoff.on_exception(
         wait_gen=backoff.expo,

--- a/tap_youtube_analytics/client.py
+++ b/tap_youtube_analytics/client.py
@@ -127,6 +127,18 @@ class Client:
 
         kwargs.setdefault("stream", True)
 
+        @backoff.on_exception(
+            wait_gen=backoff.expo,
+            exception=(
+                ConnectionResetError,
+                ConnectionError,
+                ChunkedEncodingError,
+                Timeout,
+                YoutubeAnalyticsBackoffError,
+            ),
+            max_tries=7,
+            factor=3,
+        )
         def _row_iterator() -> Iterator[Dict[str, Any]]:
             with metrics.http_request_timer(endpoint) as timer:
                 with self._session.request(

--- a/tap_youtube_analytics/client.py
+++ b/tap_youtube_analytics/client.py
@@ -210,8 +210,8 @@ class Client:
             Timeout,
             YoutubeAnalyticsBackoffError
         ),
-        max_tries=5,
-        factor=2,
+        max_tries=7,
+        factor=3,
     )
     def __make_request(self, method: str, path=None, url=None, **kwargs) -> Optional[Mapping[Any, Any]]:
         """Performs HTTP Operations

--- a/tap_youtube_analytics/client.py
+++ b/tap_youtube_analytics/client.py
@@ -178,8 +178,8 @@ class Client:
             Timeout,
             YoutubeAnalyticsBackoffError
         ),
-        max_tries=5,
-        factor=2,
+        max_tries=7,
+        factor=3,
     )
     def __make_request_raw(self, method: str, url=None, **kwargs) -> Optional[str]:
         """Performs HTTP Operations for raw data (like CSV)"""

--- a/tap_youtube_analytics/streams/abstracts.py
+++ b/tap_youtube_analytics/streams/abstracts.py
@@ -133,7 +133,7 @@ class BaseStream(ABC):
                 url=url,
                 path=self.path,
                 params=self.params,
-                endpoint=self.tap_stream_id
+                endpoint=self.url_endpoint
             )
             if not response or response is None or response == {}:
                 LOGGER.info("Data not found for endpoint: %s", self.url_endpoint)
@@ -490,7 +490,7 @@ class ReportStream(IncrementalStream):
                 jobs_response = self.client.get(
                     url=jobs_url,
                     params=jobs_params,
-                    endpoint=self.tap_stream_id
+                    endpoint=f"{self.client.reporting_url}/jobs"
                 )
 
                 if not jobs_response:
@@ -527,7 +527,7 @@ class ReportStream(IncrementalStream):
                         url=self.client.reporting_url,
                         path='jobs',
                         data=create_payload,
-                        endpoint=self.tap_stream_id
+                        endpoint='job_create'
                     ) or {}
                 except YoutubeAnalyticsNotFoundError:
                     # The YouTube Reporting API returns 404 when you attempt to
@@ -536,7 +536,7 @@ class ReportStream(IncrementalStream):
                     # behalf). These types are already exposed through the jobs
                     # list with includeSystemManaged=true, so if no match was
                     # found above the type simply isn't available for this
-                    # account. Log and skip rather than aborting the sync.
+                    # account. Log and re-raise to halt the sync.
                     LOGGER.warning(
                         "Cannot create a reporting job for report type %s "
                         "(system-managed types cannot have user-owned jobs; "
@@ -545,7 +545,7 @@ class ReportStream(IncrementalStream):
                         report_type,
                         self.tap_stream_id,
                     )
-                    return
+                    raise
 
             if not target_job:
                 LOGGER.info(
@@ -577,7 +577,7 @@ class ReportStream(IncrementalStream):
                 reports_response = self.client.get(
                     url=reports_url,
                     params=reports_params,
-                    endpoint=self.tap_stream_id
+                    endpoint=f"{self.client.reporting_url}/jobs/{job_id}/reports"
                 )
 
                 if not reports_response:
@@ -597,7 +597,7 @@ class ReportStream(IncrementalStream):
 
                     try:
                         row_count = 0
-                        for record in self.client.get_report(url=download_url, endpoint=self.tap_stream_id):
+                        for record in self.client.get_report(url=download_url, endpoint=download_url):
                             row_count += 1
                             yield (record, report)
 
@@ -719,6 +719,7 @@ class ReportStream(IncrementalStream):
                     self.tap_stream_id,
                     err,
                 )
+                raise
 
             state = self.write_bookmark(
                 state,

--- a/tap_youtube_analytics/streams/abstracts.py
+++ b/tap_youtube_analytics/streams/abstracts.py
@@ -21,6 +21,7 @@ from singer import (
 from tap_youtube_analytics.exceptions import (
     YoutubeAnalyticsError,
     YoutubeAnalyticsForbiddenError,
+    YoutubeAnalyticsNotFoundError,
 )
 
 LOGGER = get_logger()
@@ -132,7 +133,7 @@ class BaseStream(ABC):
                 url=url,
                 path=self.path,
                 params=self.params,
-                endpoint=self.url_endpoint
+                endpoint=self.tap_stream_id
             )
             if not response or response is None or response == {}:
                 LOGGER.info("Data not found for endpoint: %s", self.url_endpoint)
@@ -489,7 +490,7 @@ class ReportStream(IncrementalStream):
                 jobs_response = self.client.get(
                     url=jobs_url,
                     params=jobs_params,
-                    endpoint=f"{self.client.reporting_url}/jobs"
+                    endpoint=self.tap_stream_id
                 )
 
                 if not jobs_response:
@@ -514,19 +515,37 @@ class ReportStream(IncrementalStream):
             if not target_job and hasattr(self, 'report_type'):
                 report_type = getattr(self, 'report_type', None)
                 LOGGER.info(
-                    "No existing job for report type %s. Creating new job.",
+                    "No existing job for report type %s. Attempting to create new job.",
                     report_type,
                 )
                 create_payload = {
                     'name': self.tap_stream_id,
                     'reportTypeId': report_type,
                 }
-                target_job = self.client.post(
-                    url=self.client.reporting_url,
-                    path='jobs',
-                    data=create_payload,
-                    endpoint='job_create'
-                ) or {}
+                try:
+                    target_job = self.client.post(
+                        url=self.client.reporting_url,
+                        path='jobs',
+                        data=create_payload,
+                        endpoint=self.tap_stream_id
+                    ) or {}
+                except YoutubeAnalyticsNotFoundError:
+                    # The YouTube Reporting API returns 404 when you attempt to
+                    # create a user-owned job for a system-managed report type
+                    # (e.g. content_owner_* types that YouTube manages on your
+                    # behalf). These types are already exposed through the jobs
+                    # list with includeSystemManaged=true, so if no match was
+                    # found above the type simply isn't available for this
+                    # account. Log and skip rather than aborting the sync.
+                    LOGGER.warning(
+                        "Cannot create a reporting job for report type %s "
+                        "(system-managed types cannot have user-owned jobs; "
+                        "verify the report type is available for this account). "
+                        "Skipping stream %s.",
+                        report_type,
+                        self.tap_stream_id,
+                    )
+                    return
 
             if not target_job:
                 LOGGER.info(
@@ -558,7 +577,7 @@ class ReportStream(IncrementalStream):
                 reports_response = self.client.get(
                     url=reports_url,
                     params=reports_params,
-                    endpoint=f"{self.client.reporting_url}/jobs/{job_id}/reports"
+                    endpoint=self.tap_stream_id
                 )
 
                 if not reports_response:
@@ -578,7 +597,7 @@ class ReportStream(IncrementalStream):
 
                     try:
                         row_count = 0
-                        for record in self.client.get_report(url=download_url, endpoint=download_url):
+                        for record in self.client.get_report(url=download_url, endpoint=self.tap_stream_id):
                             row_count += 1
                             yield (record, report)
 
@@ -596,7 +615,7 @@ class ReportStream(IncrementalStream):
 
         except YoutubeAnalyticsForbiddenError as err:
             LOGGER.error(
-                "YouTube Reporting API workflow failed with permission error: %s",
+                "YouTube Reporting API workflow failed: %s",
                 err,
             )
             raise
@@ -646,50 +665,60 @@ class ReportStream(IncrementalStream):
         self.update_params(updated_since=effective_start)
 
         with metrics.record_counter(self.tap_stream_id) as counter:
-            for item in self.get_records(isreport=True):
-                if not item:
-                    continue
+            try:
+                for item in self.get_records(isreport=True):
+                    if not item:
+                        continue
 
-                # Support either (row, report) tuples or just row dicts
-                if isinstance(item, tuple) and len(item) == 2:
-                    record, report = item
-                else:
-                    record, report = item, {}
+                    # Support either (row, report) tuples or just row dicts
+                    if isinstance(item, tuple) and len(item) == 2:
+                        record, report = item
+                    else:
+                        record, report = item, {}
 
-                dims = getattr(self, "dimensions", [])
+                    dims = getattr(self, "dimensions", [])
 
-                transformed_record = transformer.transform(
-                    self.transform_report_record(record, dims, report),
-                    self.schema,
-                    self.metadata
+                    transformed_record = transformer.transform(
+                        self.transform_report_record(record, dims, report),
+                        self.schema,
+                        self.metadata
+                    )
+
+                    record_time_raw = transformed_record.get(self.replication_keys[0])
+                    record_dttm = None
+                    if record_time_raw:
+                        try:
+                            normalized_time = self._normalize_datetime(record_time_raw)
+                            record_dttm = utils.strptime_to_utc(normalized_time)
+                        except Exception as err:
+                            LOGGER.warning(
+                                "Failed to parse record timestamp %s for stream %s: %s",
+                                record_time_raw,
+                                self.tap_stream_id,
+                                err,
+                            )
+
+                    if record_dttm and record_dttm < effective_start_dttm:
+                        continue
+
+                    if record_dttm and record_dttm > current_max_dttm:
+                        current_max_dttm = record_dttm
+
+                    if self.is_selected():
+                        write_record(self.tap_stream_id, transformed_record)
+                        counter.increment()
+
+                    for child in self.child_to_sync:
+                        child.sync(state=state, transformer=transformer, parent_obj=record)
+
+            except YoutubeAnalyticsForbiddenError as err:
+                LOGGER.warning(
+                    "Skipping stream %s: insufficient permissions (403). "
+                    "Verify OAuth scopes include yt-analytics.readonly and, "
+                    "for revenue streams, yt-analytics-monetary.readonly. Error: %s",
+                    self.tap_stream_id,
+                    err,
                 )
-
-                record_time_raw = transformed_record.get(self.replication_keys[0])
-                record_dttm = None
-                if record_time_raw:
-                    try:
-                        normalized_time = self._normalize_datetime(record_time_raw)
-                        record_dttm = utils.strptime_to_utc(normalized_time)
-                    except Exception as err:
-                        LOGGER.warning(
-                            "Failed to parse record timestamp %s for stream %s: %s",
-                            record_time_raw,
-                            self.tap_stream_id,
-                            err,
-                        )
-
-                if record_dttm and record_dttm < effective_start_dttm:
-                    continue
-
-                if record_dttm and record_dttm > current_max_dttm:
-                    current_max_dttm = record_dttm
-
-                if self.is_selected():
-                    write_record(self.tap_stream_id, transformed_record)
-                    counter.increment()
-
-                for child in self.child_to_sync:
-                    child.sync(state=state, transformer=transformer, parent_obj=record)
 
             state = self.write_bookmark(
                 state,

--- a/tap_youtube_analytics/streams/abstracts.py
+++ b/tap_youtube_analytics/streams/abstracts.py
@@ -541,7 +541,7 @@ class ReportStream(IncrementalStream):
                         "Cannot create a reporting job for report type %s "
                         "(system-managed types cannot have user-owned jobs; "
                         "verify the report type is available for this account). "
-                        "Skipping stream %s.",
+                        "Failing stream %s.",
                         report_type,
                         self.tap_stream_id,
                     )
@@ -713,7 +713,7 @@ class ReportStream(IncrementalStream):
 
             except YoutubeAnalyticsForbiddenError as err:
                 LOGGER.warning(
-                    "Skipping stream %s: insufficient permissions (403). "
+                    "Failing stream %s: insufficient permissions (403). "
                     "Verify OAuth scopes include yt-analytics.readonly and, "
                     "for revenue streams, yt-analytics-monetary.readonly. Error: %s",
                     self.tap_stream_id,

--- a/tap_youtube_analytics/streams/abstracts.py
+++ b/tap_youtube_analytics/streams/abstracts.py
@@ -615,7 +615,7 @@ class ReportStream(IncrementalStream):
 
         except YoutubeAnalyticsForbiddenError as err:
             LOGGER.error(
-                "YouTube Reporting API workflow failed: %s",
+                "YouTube Reporting API workflow failed with permission error: %s",
                 err,
             )
             raise

--- a/tests/unittests/test_streams.py
+++ b/tests/unittests/test_streams.py
@@ -111,9 +111,9 @@ class TestReportStream(unittest.TestCase):
         ])
 
         def get_side_effect(url=None, params=None, endpoint=None):
-            if url and url.endswith("/jobs"):
+            if endpoint and endpoint.endswith("/jobs"):
                 return next(job_calls)
-            if url and "/reports" in url:
+            if endpoint and "/reports" in endpoint:
                 try:
                     result = next(report_calls)
                 except StopIteration:

--- a/tests/unittests/test_streams.py
+++ b/tests/unittests/test_streams.py
@@ -111,9 +111,9 @@ class TestReportStream(unittest.TestCase):
         ])
 
         def get_side_effect(url=None, params=None, endpoint=None):
-            if endpoint.endswith("/jobs"):
+            if url and url.endswith("/jobs"):
                 return next(job_calls)
-            if endpoint.endswith("/reports"):
+            if url and "/reports" in url:
                 try:
                     result = next(report_calls)
                 except StopIteration:


### PR DESCRIPTION
# Description of change
The tap is currently hitting a lot of 429s when syncing data and this pr seeks to remediate that issue by increasing the backoff strategy.

Additionally adds more verbose logging to 403s and 404s to help triage specific tables

# Manual QA steps
 - Created extraction specs for youtube-analytics and ran several syncs
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [x] this PR has been written with the help of GitHub Copilot or another generative AI tool
